### PR TITLE
Hey.

### DIFF
--- a/locking/__init__.py
+++ b/locking/__init__.py
@@ -1,9 +1,6 @@
-import sys
-import logging
 from django.conf import settings
+import logging
 
 LOCK_TIMEOUT = getattr(settings, 'LOCK_TIMEOUT', 1800)
-LOCKING_LOG_LEVEL = getattr(settings, 'LOCKING_LOG_LEVEL', logging.INFO)
-FORMAT = "[locking] [%(levelname)s] %(message)s"
 
-logging.basicConfig(stream=sys.stderr, level=LOCKING_LOG_LEVEL, format=FORMAT)
+logger = logging.getLogger('django.locker')

--- a/locking/decorators.py
+++ b/locking/decorators.py
@@ -4,7 +4,7 @@ from django.http import HttpResponse
 from django.contrib.contenttypes.models import ContentType
 
 from locking.models import LockableModel
-from locking import logging
+from locking import logger
 
 def user_may_change_model(fn):
     def view(request, app, model, *vargs, **kwargs):
@@ -36,7 +36,7 @@ def is_lockable(fn):
 def log(view):
     def decorated_view(*vargs, **kwargs):
         response = view(*vargs, **kwargs)
-        logging.debug("Sending a request: \n\t%s" % (response.content))
+        logger.debug("Sending a request: \n\t%s" % (response.content))
         return response
     
     return decorated_view

--- a/locking/models.py
+++ b/locking/models.py
@@ -6,7 +6,7 @@ from django.db import models
 from django.conf import settings
 from django.contrib.auth import models as auth
 
-from locking import LOCK_TIMEOUT, logging
+from locking import LOCK_TIMEOUT, logger
 
 class ObjectLockedError(IOError):
     pass
@@ -92,7 +92,7 @@ class LockableModel(models.Model):
         
         Don't use hard locks unless you really need them. See :doc:`design`.
         """
-        logging.info("Attempting to initiate a lock for user `%s`" % user)
+        logger.info("Attempting to initiate a lock for user `%s`" % user)
 
         if not isinstance(user, auth.User):
             raise ValueError("You should pass a valid auth.User to lock_for.")
@@ -105,7 +105,7 @@ class LockableModel(models.Model):
             self._locked_by = user
             self._hard_lock = self.__init_hard_lock = hard_lock
             date = self.locked_at.strftime("%H:%M:%S")
-            logging.info("Initiated a %s lock for `%s` at %s" % (self.lock_type, self.locked_by, self.locked_at))     
+            logger.info("Initiated a %s lock for `%s` at %s" % (self.lock_type, self.locked_by, self.locked_at))     
 
     def unlock(self):
         """
@@ -114,7 +114,7 @@ class LockableModel(models.Model):
         locks themselves. Otherwise, use ``unlock_for``.
         """
         self._locked_at = self._locked_by = None
-        logging.info("Disengaged lock on `%s`" % self)
+        logger.info("Disengaged lock on `%s`" % self)
     
     def unlock_for(self, user):
         """
@@ -125,7 +125,7 @@ class LockableModel(models.Model):
         Will raise a ObjectLockedError exception when the current user isn't authorized to
         unlock the object.
         """
-        logging.info("Attempting to open up a lock on `%s` by user `%s`" % (self, user))
+        logger.info("Attempting to open up a lock on `%s` by user `%s`" % (self, user))
     
         # refactor: should raise exceptions instead
         if self.is_locked_by(user):
@@ -139,13 +139,13 @@ class LockableModel(models.Model):
         ``lock_applies_to`` is used to ascertain whether a user is allowed
         to edit a locked object.
         """
-        logging.info("Checking if the lock on `%s` applies to user `%s`" % (self, user))
+        logger.info("Checking if the lock on `%s` applies to user `%s`" % (self, user))
         # a lock does not apply to the person who initiated the lock
         if self.is_locked and self.locked_by != user:
-            logging.info("Lock applies.")
+            logger.info("Lock applies.")
             return True
         else:
-            logging.info("Lock does not apply.")
+            logger.info("Lock does not apply.")
             return False
     
     def is_locked_by(self, user):

--- a/locking/views.py
+++ b/locking/views.py
@@ -4,7 +4,7 @@ from django.http import HttpResponse
 from django.core.urlresolvers import reverse
 
 from locking.decorators import user_may_change_model, is_lockable, log
-from locking import utils, LOCK_TIMEOUT, logging, models
+from locking import utils, LOCK_TIMEOUT, logger, models
 
 """
 These views are called from javascript to open and close assets (objects), in order


### PR DESCRIPTION
Loggers shouldn't be setup in the library.  Loggers should be setup by the end user in django.

I changed your code so that it follows this pattern...

logger = logging.getLogger('django.locker')

If the user wants to see push the locker logs into their log file, then it's up to them.  Pushing stuff to stderr by default is kind of annoying.

It will throw a warning if the user doesn't have any django. loggers setup (but in 1.3 there is one setup by default).

If you want to ensure the warning is avoided you can add this code...

if not logger.handlers:
   logger.addHandler(NullHandler)
